### PR TITLE
Update dependencies list in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ disk-monitor/
 |-----------|----------|-------------------------------------|
 | FastAPI   | >=0.68.0 | Framework web para a API            |
 | uvicorn   | >=0.15.0 | Servidor ASGI                       |
+| jinja2    | >=3.1.6  | Template engine para Python web     |
 | psutil    | >=5.8.0  | Coleta de métricas do sistema       |
 | pandas    | >=1.3.0  | Manipulação de dados                |
 | plotly    | >=5.3.0  | Geração de gráficos interativos     |
@@ -47,7 +48,7 @@ yay -S python-fastapi uvicorn python-psutil python-pandas python-plotly
 ### Para Debian/Ubuntu:
 ```bash
 sudo apt install python3-pip
-pip install fastapi uvicorn psutil pandas plotly
+pip install fastapi uvicorn psutil pandas plotly jinja2
 ```
 
 ### Via pip (recomendado):
@@ -61,7 +62,7 @@ pip install -r requirements.txt  # Crie o arquivo com as dependências listadas 
 
 ## 🚀 Como Usar
 
-1. Inicie o servidor:
+1. Na raiz do projeto, inicie o servidor:
 ```bash
 uvicorn api:app --reload
 ```


### PR DESCRIPTION
The changes made to the `README.md` file are as follows:

1. **Dependency Addition**:
   - The `jinja2` library (version `>=3.1.6`) has been added to the list of dependencies in the table of required packages. This library is a template engine for Python web applications.

2. **Installation Instructions Update**:
   - For **Debian/Ubuntu**, the `pip install` command now includes `jinja2` alongside the other dependencies (`fastapi`, `uvicorn`, `psutil`, `pandas`, `plotly`).
   - The updated command is:
     ```bash
     pip install fastapi uvicorn psutil pandas plotly jinja2
     ```

3. **Usage Instruction Clarification**:
   - In the **"How to Use"** section, the instruction for starting the server has been updated to clarify that the command should be run from the root of the project:
     ```bash
     uvicorn api:app --reload
     ```
   - The text now explicitly states: "Na raiz do projeto, inicie o servidor" (translated: "In the root of the project, start the server").

These changes improve the documentation by ensuring that the new dependency (`jinja2`) is clearly listed and included in installation steps. Additionally, the usage instructions are made more precise for users.